### PR TITLE
fix: correct inventory bridge reference from qs-inventory to qb-inven…

### DIFF
--- a/BRIDGE/server/inventory.lua
+++ b/BRIDGE/server/inventory.lua
@@ -19,7 +19,7 @@ if BRIDGE.Inventory  == "ox_inventory" then
 end
 
 if BRIDGE.Inventory == "qb_inventory" then
-    Inventory = exports['qs-inventory']
+    Inventory = exports['qb-inventory']
 end
 
 if BRIDGE.Inventory == "quasar_inventory" then


### PR DESCRIPTION
## Changes
This PR corrects an incorrect inventory system reference in the bridge configuration.

## Issue
#5 

## Details
- **File:** `BRIDGE/server/inventory.lua` (line 22)
- **Change:** Updated reference from `"qs-inventory"` to `"qb-inventory"`

## Reason
The current reference to `"qs-inventory"` is incorrect and should be `"qb-inventory"` to ensure proper compatibility with the QB-Core framework's standard inventory system.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)